### PR TITLE
feat: #6 CSV Import/Export

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -106,14 +106,14 @@
 
 ---
 
-## Phase 6 — CSV Import/Export
+## Phase 6 — CSV Import/Export ✅
 
 **커밋 목표:** `feat: #6 CSV Import/Export`
 
-- [ ] `components/csv-export-button.tsx` — `wbs-YYYY-MM-DD.csv` 다운로드
-- [ ] `components/csv-import-button.tsx` — 파일 선택 → 미리보기 → 적용
-- [ ] `app/api/tasks/import/route.ts` — 배치 insert
-- [ ] J10(Export), J11(Import 성공), J12(Import 부분 오류) 시나리오 검증
+- [x] `components/csv-export-button.tsx` — `wbs-YYYY-MM-DD.csv` 다운로드
+- [x] `components/csv-import-button.tsx` — 파일 선택 → 미리보기 → 적용
+- [x] `app/api/tasks/import/route.ts` — 배치 insert
+- [x] J10(Export), J11(Import 성공), J12(Import 부분 오류) 시나리오 검증
 
 ---
 

--- a/app/api/tasks/import/route.ts
+++ b/app/api/tasks/import/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+import { db } from '@/lib/db'
+import { tasks } from '@/lib/db/schema'
+
+const RowSchema = z.object({
+  title: z.string().min(1),
+  description: z.string().nullable().optional(),
+  assignee: z.string().nullable().optional(),
+  status: z.enum(['todo', 'doing', 'done']).optional(),
+  progress: z.number().int().min(0).max(100).optional(),
+  startDate: z.string().nullable().optional(),
+  dueDate: z.string().nullable().optional(),
+  parentId: z.string().uuid().nullable().optional(),
+})
+
+const ImportSchema = z.object({
+  rows: z.array(RowSchema),
+})
+
+export async function POST(request: Request) {
+  const body = await request.json()
+  const parsed = ImportSchema.safeParse(body)
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 })
+  }
+  const { rows } = parsed.data
+  if (rows.length === 0) {
+    return NextResponse.json({ inserted: 0 })
+  }
+  const inserted = await db.insert(tasks).values(
+    rows.map(r => ({
+      title: r.title,
+      description: r.description ?? null,
+      assignee: r.assignee ?? null,
+      status: r.status ?? 'todo',
+      progress: r.progress ?? 0,
+      startDate: r.startDate ?? null,
+      dueDate: r.dueDate ?? null,
+      parentId: r.parentId ?? null,
+    }))
+  ).returning()
+  return NextResponse.json({ inserted: inserted.length }, { status: 201 })
+}

--- a/components/csv-export-button.tsx
+++ b/components/csv-export-button.tsx
@@ -1,0 +1,66 @@
+'use client'
+
+import { Button } from '@chakra-ui/react'
+import type { Task } from '@/lib/db/schema'
+
+const HEADERS = ['제목', '설명', '담당자', '상태', '진행률', '시작일', '목표 기한', '상위 작업 제목']
+
+function escapeCell(v: string | null | undefined): string {
+  const s = v ?? ''
+  if (s.includes(',') || s.includes('"') || s.includes('\n')) {
+    return `"${s.replace(/"/g, '""')}"`
+  }
+  return s
+}
+
+function statusLabel(s: string): string {
+  return s === 'done' ? '완료' : s === 'doing' ? '진행 중' : '할 일'
+}
+
+interface Props {
+  tasks: Task[]
+}
+
+export default function CsvExportButton({ tasks }: Props) {
+  const handleExport = () => {
+    const idToTitle = Object.fromEntries(tasks.map(t => [t.id, t.title]))
+
+    const rows = tasks.map(t => [
+      escapeCell(t.title),
+      escapeCell(t.description),
+      escapeCell(t.assignee),
+      escapeCell(statusLabel(t.status)),
+      String(t.progress),
+      escapeCell(t.startDate),
+      escapeCell(t.dueDate),
+      escapeCell(t.parentId ? idToTitle[t.parentId] : ''),
+    ])
+
+    const csv = [HEADERS.join(','), ...rows.map(r => r.join(','))].join('\n')
+    const date = new Date().toLocaleDateString('en-CA')
+    const blob = new Blob(['﻿' + csv], { type: 'text/csv;charset=utf-8;' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = `wbs-${date}.csv`
+    a.click()
+    URL.revokeObjectURL(url)
+  }
+
+  return (
+    <Button
+      onClick={handleExport}
+      bg="transparent"
+      color="#898989"
+      border="1px solid #363636"
+      borderRadius="6px"
+      px={4}
+      h="36px"
+      fontSize="14px"
+      fontWeight={500}
+      _hover={{ bg: '#2e2e2e', color: '#fafafa' }}
+    >
+      CSV 내보내기
+    </Button>
+  )
+}

--- a/components/csv-import-button.tsx
+++ b/components/csv-import-button.tsx
@@ -173,19 +173,11 @@ export default function CsvImportButton({ tasks, onImported }: Props) {
     if (!preview) return
     setApplying(true)
 
-    // CSV 내 순서대로 삽입하며 parentId를 동적으로 해결
+    // 순차 삽입 — 삽입 직후 titleToId를 갱신해 같은 배치 내 자식이 신규 부모를 우선 참조하도록 함
     const titleToId: Record<string, string> = Object.fromEntries(tasks.map(t => [t.title, t.id]))
-    const toInsert = preview.rows.map(r => {
-      let parentId = r.parentId
-      if (!parentId && r.parentTitle && titleToId[r.parentTitle]) {
-        parentId = titleToId[r.parentTitle]
-      }
-      return { ...r, parentId }
-    })
 
-    // 순차 삽입 (CSV 내 부모가 먼저 등장한다는 전제)
-    for (const row of toInsert) {
-      const parentId = row.parentId ?? (row.parentTitle ? titleToId[row.parentTitle] ?? null : null)
+    for (const row of preview.rows) {
+      const parentId = row.parentTitle ? (titleToId[row.parentTitle] ?? null) : null
       const res = await fetch('/api/tasks', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -202,7 +194,7 @@ export default function CsvImportButton({ tasks, onImported }: Props) {
       })
       if (res.ok) {
         const created = await res.json()
-        titleToId[row.title] = created.id
+        titleToId[row.title] = created.id  // 이후 행이 이 Task를 부모로 참조 가능
       }
     }
 
@@ -241,8 +233,7 @@ export default function CsvImportButton({ tasks, onImported }: Props) {
 
             <Box bg="rgba(62,207,142,0.08)" border="1px solid rgba(62,207,142,0.25)" borderRadius="8px" p={3} mb={4}>
               <Text fontSize="14px" color="#3ecf8e">
-                {preview.rows.length}개 작업을 추가합니다.
-                {preview.excluded.length > 0 && ` 제외 ${preview.excluded.length}건.`}
+                {preview.rows.length}개 작업을 추가합니다. 제외 {preview.excluded.length}건.
               </Text>
             </Box>
 

--- a/components/csv-import-button.tsx
+++ b/components/csv-import-button.tsx
@@ -1,0 +1,296 @@
+'use client'
+
+import { useRef, useState } from 'react'
+import { Box, Button, Flex, Text } from '@chakra-ui/react'
+import type { Task } from '@/lib/db/schema'
+
+type Status = 'todo' | 'doing' | 'done'
+
+const STATUS_MAP: Record<string, Status> = {
+  '할 일': 'todo', 'todo': 'todo',
+  '진행 중': 'doing', 'doing': 'doing',
+  '완료': 'done', 'done': 'done',
+}
+
+interface ParsedRow {
+  title: string
+  description: string | null
+  assignee: string | null
+  status: Status
+  progress: number
+  startDate: string | null
+  dueDate: string | null
+  parentTitle: string | null
+  parentId: string | null
+  warnings: string[]
+}
+
+interface ExcludedRow {
+  line: number
+  reason: string
+}
+
+interface Preview {
+  rows: ParsedRow[]
+  excluded: ExcludedRow[]
+}
+
+function parseDate(val: string): string | null {
+  if (!val.trim()) return null
+  const d = new Date(val.trim())
+  if (isNaN(d.getTime())) return null
+  return val.trim()
+}
+
+function parseCsv(text: string): string[][] {
+  const result: string[][] = []
+  let row: string[] = []
+  let cell = ''
+  let inQuotes = false
+  for (let i = 0; i < text.length; i++) {
+    const c = text[i]
+    if (inQuotes) {
+      if (c === '"' && text[i + 1] === '"') { cell += '"'; i++ }
+      else if (c === '"') inQuotes = false
+      else cell += c
+    } else {
+      if (c === '"') inQuotes = true
+      else if (c === ',') { row.push(cell); cell = '' }
+      else if (c === '\n') { row.push(cell); result.push(row); row = []; cell = '' }
+      else if (c === '\r') { /* skip */ }
+      else cell += c
+    }
+  }
+  if (cell || row.length) { row.push(cell); result.push(row) }
+  return result
+}
+
+function buildPreview(text: string, existingTasks: Task[]): Preview {
+  const lines = parseCsv(text)
+  if (lines.length < 2) return { rows: [], excluded: [] }
+
+  const header = lines[0].map(h => h.trim())
+  const idx = (name: string) => header.indexOf(name)
+  const I = {
+    title: idx('제목'), description: idx('설명'), assignee: idx('담당자'),
+    status: idx('상태'), progress: idx('진행률'),
+    startDate: idx('시작일'), dueDate: idx('목표 기한'), parentTitle: idx('상위 작업 제목'),
+  }
+
+  const existingTitleMap = Object.fromEntries(existingTasks.map(t => [t.title, t.id]))
+  const rows: ParsedRow[] = []
+  const excluded: ExcludedRow[] = []
+
+  for (let i = 1; i < lines.length; i++) {
+    const line = lines[i]
+    if (line.every(c => !c.trim())) continue
+
+    const get = (fi: number) => (fi >= 0 ? (line[fi] ?? '').trim() : '')
+    const title = get(I.title)
+
+    if (!title) {
+      excluded.push({ line: i + 1, reason: '제목 누락' })
+      continue
+    }
+
+    const warnings: string[] = []
+    const rawStart = get(I.startDate)
+    const rawDue = get(I.dueDate)
+    const startDate = parseDate(rawStart)
+    const dueDate = parseDate(rawDue)
+    if (rawStart && !startDate) warnings.push('시작일 형식 오류 → 비움')
+    if (rawDue && !dueDate) warnings.push('목표 기한 형식 오류 → 비움')
+
+    const rawStatus = get(I.status)
+    const status: Status = STATUS_MAP[rawStatus] ?? 'todo'
+    if (rawStatus && !STATUS_MAP[rawStatus]) warnings.push(`상태 "${rawStatus}" → 할 일로 대체`)
+
+    const rawProgress = get(I.progress)
+    const progress = rawProgress ? Math.min(100, Math.max(0, parseInt(rawProgress, 10) || 0)) : 0
+    const parentTitle = get(I.parentTitle) || null
+    let parentId: string | null = null
+
+    if (parentTitle) {
+      if (existingTitleMap[parentTitle]) {
+        parentId = existingTitleMap[parentTitle]
+      } else {
+        warnings.push(`상위 작업 "${parentTitle}" 매칭 실패 → 최상위로 처리`)
+      }
+    }
+
+    rows.push({
+      title,
+      description: get(I.description) || null,
+      assignee: get(I.assignee) || null,
+      status,
+      progress,
+      startDate,
+      dueDate,
+      parentTitle,
+      parentId,
+      warnings,
+    })
+  }
+
+  // CSV 내 부모-자식 관계 해결 (existingTasks에 없는 부모가 CSV 안에 있는 경우)
+  const csvTitleToIdx: Record<string, number> = {}
+  rows.forEach((r, i) => { csvTitleToIdx[r.title] = i })
+  rows.forEach(r => {
+    if (r.parentTitle && !r.parentId) {
+      const csvIdx = csvTitleToIdx[r.parentTitle]
+      if (csvIdx !== undefined) {
+        r.warnings = r.warnings.filter(w => !w.startsWith('상위 작업'))
+      }
+    }
+  })
+
+  return { rows, excluded }
+}
+
+interface Props {
+  tasks: Task[]
+  onImported: () => void
+}
+
+export default function CsvImportButton({ tasks, onImported }: Props) {
+  const fileRef = useRef<HTMLInputElement>(null)
+  const [preview, setPreview] = useState<Preview | null>(null)
+  const [applying, setApplying] = useState(false)
+
+  const handleFile = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+    const reader = new FileReader()
+    reader.onload = (ev) => {
+      const text = (ev.target?.result as string) ?? ''
+      setPreview(buildPreview(text, tasks))
+    }
+    reader.readAsText(file, 'utf-8')
+    e.target.value = ''
+  }
+
+  const handleApply = async () => {
+    if (!preview) return
+    setApplying(true)
+
+    // CSV 내 순서대로 삽입하며 parentId를 동적으로 해결
+    const titleToId: Record<string, string> = Object.fromEntries(tasks.map(t => [t.title, t.id]))
+    const toInsert = preview.rows.map(r => {
+      let parentId = r.parentId
+      if (!parentId && r.parentTitle && titleToId[r.parentTitle]) {
+        parentId = titleToId[r.parentTitle]
+      }
+      return { ...r, parentId }
+    })
+
+    // 순차 삽입 (CSV 내 부모가 먼저 등장한다는 전제)
+    for (const row of toInsert) {
+      const parentId = row.parentId ?? (row.parentTitle ? titleToId[row.parentTitle] ?? null : null)
+      const res = await fetch('/api/tasks', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          title: row.title,
+          description: row.description,
+          assignee: row.assignee,
+          status: row.status,
+          progress: row.progress,
+          startDate: row.startDate,
+          dueDate: row.dueDate,
+          parentId,
+        }),
+      })
+      if (res.ok) {
+        const created = await res.json()
+        titleToId[row.title] = created.id
+      }
+    }
+
+    setApplying(false)
+    setPreview(null)
+    onImported()
+  }
+
+  return (
+    <>
+      <input ref={fileRef} type="file" accept=".csv" style={{ display: 'none' }} onChange={handleFile} />
+      <Button
+        onClick={() => fileRef.current?.click()}
+        bg="transparent"
+        color="#898989"
+        border="1px solid #363636"
+        borderRadius="6px"
+        px={4}
+        h="36px"
+        fontSize="14px"
+        fontWeight={500}
+        _hover={{ bg: '#2e2e2e', color: '#fafafa' }}
+      >
+        CSV 불러오기
+      </Button>
+
+      {preview && (
+        <>
+          <Box position="fixed" inset="0" bg="rgba(0,0,0,0.75)" zIndex={200} onClick={() => setPreview(null)} />
+          <Box
+            position="fixed" top="50%" left="50%" transform="translate(-50%,-50%)"
+            zIndex={201} bg="#171717" border="1px solid #363636" borderRadius="12px"
+            p={6} w="520px" maxW="92vw" maxH="80vh" overflowY="auto"
+          >
+            <Text fontSize="18px" fontWeight={500} color="#fafafa" mb={4}>CSV 가져오기 미리보기</Text>
+
+            <Box bg="rgba(62,207,142,0.08)" border="1px solid rgba(62,207,142,0.25)" borderRadius="8px" p={3} mb={4}>
+              <Text fontSize="14px" color="#3ecf8e">
+                {preview.rows.length}개 작업을 추가합니다.
+                {preview.excluded.length > 0 && ` 제외 ${preview.excluded.length}건.`}
+              </Text>
+            </Box>
+
+            {preview.rows.map((r, i) => (
+              r.warnings.length > 0 && (
+                <Box key={i} mb={2} p={3} bg="#1a1a1a" border="1px solid #363636" borderRadius="6px">
+                  <Text fontSize="13px" color="#fafafa" mb={1}>{r.title}</Text>
+                  {r.warnings.map((w, j) => (
+                    <Text key={j} fontSize="12px" color="#f59e0b">⚠ {w}</Text>
+                  ))}
+                </Box>
+              )
+            ))}
+
+            {preview.excluded.length > 0 && (
+              <Box mb={4}>
+                <Text fontSize="13px" color="#898989" mb={2}>제외 항목</Text>
+                {preview.excluded.map((e, i) => (
+                  <Box key={i} mb={1} p={3} bg="#1a1a1a" border="1px solid rgba(248,113,113,0.3)" borderRadius="6px">
+                    <Text fontSize="12px" color="#f87171">{e.line}행: {e.reason}</Text>
+                  </Box>
+                ))}
+              </Box>
+            )}
+
+            <Flex justify="flex-end" gap={2} mt={4}>
+              <Button
+                onClick={() => setPreview(null)}
+                bg="transparent" color="#898989" border="1px solid #363636"
+                borderRadius="6px" px={5} fontSize="14px" fontWeight={500}
+                _hover={{ bg: '#2e2e2e', color: '#fafafa' }}
+              >
+                취소
+              </Button>
+              <Button
+                onClick={handleApply}
+                disabled={applying || preview.rows.length === 0}
+                bg="#0f0f0f" color="#fafafa" border="1px solid #fafafa"
+                borderRadius="9999px" px={6} fontSize="14px" fontWeight={500}
+                _hover={{ opacity: 0.8 }}
+                opacity={applying ? 0.5 : 1}
+              >
+                {applying ? '적용 중...' : '적용'}
+              </Button>
+            </Flex>
+          </Box>
+        </>
+      )}
+    </>
+  )
+}

--- a/components/task-list.tsx
+++ b/components/task-list.tsx
@@ -6,6 +6,8 @@ import type { Task } from '@/lib/db/schema'
 import TaskRow from './task-row'
 import TaskFormModal from './task-form-modal'
 import TaskDeleteDialog from './task-delete-dialog'
+import CsvExportButton from './csv-export-button'
+import CsvImportButton from './csv-import-button'
 
 type TreeNode = Task & { children: TreeNode[] }
 
@@ -128,20 +130,24 @@ export default function TaskList() {
               {tasks.length}개의 Task
             </Text>
           </Box>
-          <Button
-            onClick={() => { setNewParentId(null); setIsCreateOpen(true) }}
-            bg="#0f0f0f"
-            color="#fafafa"
-            border="1px solid #fafafa"
-            borderRadius="9999px"
-            px={6}
-            h="36px"
-            fontSize="14px"
-            fontWeight={500}
-            _hover={{ opacity: 0.8 }}
-          >
-            + Task 추가
-          </Button>
+          <Flex gap={2} align="center">
+            <CsvImportButton tasks={tasks} onImported={fetchTasks} />
+            <CsvExportButton tasks={tasks} />
+            <Button
+              onClick={() => { setNewParentId(null); setIsCreateOpen(true) }}
+              bg="#0f0f0f"
+              color="#fafafa"
+              border="1px solid #fafafa"
+              borderRadius="9999px"
+              px={6}
+              h="36px"
+              fontSize="14px"
+              fontWeight={500}
+              _hover={{ opacity: 0.8 }}
+            >
+              + Task 추가
+            </Button>
+          </Flex>
         </Flex>
 
         {/* 컬럼 헤더 */}


### PR DESCRIPTION
## Summary

- `components/csv-export-button.tsx`: 현재 Task 목록 전체를 `wbs-YYYY-MM-DD.csv`로 다운로드 (상위 작업 제목 포함)
- `components/csv-import-button.tsx`: 파일 선택 → 미리보기(제외/경고 표시) → 순차 적용
- `app/api/tasks/import/route.ts`: 배치 insert API (Zod 검증)
- Import 규칙: 제목 없음 제외 / 날짜 형식 오류 → null / 허용 외 상태 → 할 일 / 부모 미매칭 → 최상위

closes #6

## Test plan

- [x] J10 CSV 내보내기 — 헤더·행수·상위 작업 제목 정상
- [x] J11 CSV 가져오기 정상 — 3개 추가, 계층 유지
- [x] J12 CSV 가져오기 부분 오류 — 제외 1건(제목 누락), 경고 1건(부모 미매칭 → 최상위)

🤖 Generated with [Claude Code](https://claude.com/claude-code)