### PR TITLE
feat: Phase 7 간트형 일정 시각화 뷰 구현

### DIFF
--- a/components/gantt-view.tsx
+++ b/components/gantt-view.tsx
@@ -1,0 +1,264 @@
+'use client'
+
+import { Box, Flex, Text } from '@chakra-ui/react'
+import type { Task } from '@/lib/db/schema'
+
+type TreeNode = Task & { children: TreeNode[] }
+
+interface GanttViewProps {
+  rows: Array<{ task: TreeNode; depth: number; hasChildren: boolean }>
+  collapsed: Set<string>
+  onToggle: (id: string) => void
+}
+
+export default function GanttView({ rows, collapsed, onToggle }: GanttViewProps) {
+  // Helper date functions
+  const addDays = (date: Date, days: number) => {
+    const result = new Date(date)
+    result.setDate(result.getDate() + days)
+    return result
+  }
+  
+  const startOfWeek = (date: Date) => {
+    const result = new Date(date)
+    const day = result.getDay()
+    const diff = result.getDate() - day
+    result.setDate(diff)
+    return result
+  }
+  
+  const differenceInDays = (dateLeft: Date, dateRight: Date) => {
+    const diffTime = Math.abs(dateLeft.getTime() - dateRight.getTime())
+    return Math.floor(diffTime / (1000 * 60 * 60 * 24))
+  }
+  
+  const isValid = (date: Date) => {
+    return !isNaN(date.getTime())
+  }
+  
+  const formatDate = (date: Date) => {
+    return `${date.getMonth() + 1}.${date.getDate()}`
+  }
+
+  // 1. Calculate overall grid date range
+  const dates = rows.flatMap(r => {
+    const d = []
+    if (r.task.startDate) {
+      const start = new Date(r.task.startDate)
+      if (isValid(start)) d.push(start)
+    }
+    if (r.task.dueDate) {
+      const due = new Date(r.task.dueDate)
+      if (isValid(due)) d.push(due)
+    }
+    return d
+  })
+
+  let minDate = new Date()
+  let maxDate = addDays(new Date(), 30)
+
+  if (dates.length > 0) {
+    minDate = new Date(Math.min(...dates.map(d => d.getTime())))
+    maxDate = new Date(Math.max(...dates.map(d => d.getTime())))
+  }
+
+  // Pad to start of week, minus 1 week, plus 2 weeks
+  minDate = addDays(startOfWeek(minDate), -7)
+  maxDate = addDays(maxDate, 14)
+
+  const totalDays = differenceInDays(maxDate, minDate) + 1
+
+  // Generate weeks
+  const weeks: Date[] = []
+  let curr = new Date(minDate)
+  while (curr <= maxDate) {
+    weeks.push(curr)
+    curr = addDays(curr, 7)
+  }
+
+  // Helper to calculate percentage position
+  const getLeftPercent = (date: Date) => {
+    const diff = differenceInDays(date, minDate)
+    return Math.max(0, Math.min(100, (diff / totalDays) * 100))
+  }
+
+  const getWidthPercent = (start: Date, end: Date) => {
+    const diff = differenceInDays(end, start) + 1
+    return Math.max(0, Math.min(100, (diff / totalDays) * 100))
+  }
+
+  const today = new Date()
+  const todayLeft = getLeftPercent(today)
+  const isTodayInRange = today >= minDate && today <= maxDate
+
+  return (
+    <Box border="1px solid #2e2e2e" borderRadius="8px" overflow="hidden" bg="#171717">
+      <Flex borderBottom="1px solid #242424">
+        {/* Header Left (Task Tree) */}
+        <Box w="300px" flexShrink={0} borderRight="1px solid #2e2e2e" p={3}>
+          <Text fontSize="12px" color="#4d4d4d" fontWeight={500} textTransform="uppercase" letterSpacing="0.05em">
+            작업명
+          </Text>
+        </Box>
+
+        {/* Header Right (Date Grid) */}
+        <Box flex={1} overflowX="auto" css={{ '&::-webkit-scrollbar': { display: 'none' } }}>
+          <Box position="relative" minW="800px" h="100%">
+            {/* Week Labels */}
+            <Flex position="absolute" top={0} left={0} right={0} bottom={0}>
+              {weeks.map((week, i) => (
+                <Box
+                  key={i}
+                  position="absolute"
+                  left={`${getLeftPercent(week)}%`}
+                  h="100%"
+                  borderLeft="1px solid #242424"
+                  px={2}
+                  pt={3}
+                >
+                  <Text fontSize="12px" color="#898989">
+                    {formatDate(week)}
+                  </Text>
+                </Box>
+              ))}
+            </Flex>
+          </Box>
+        </Box>
+      </Flex>
+
+      {/* Body */}
+      <Flex>
+        {/* Body Left (Task Tree) */}
+        <Box w="300px" flexShrink={0} borderRight="1px solid #2e2e2e">
+          {rows.map(({ task, depth, hasChildren }, i) => {
+            const isLast = i === rows.length - 1
+            const isColl = collapsed.has(task.id)
+
+            return (
+              <Flex
+                key={task.id}
+                align="center"
+                h="40px"
+                px={3}
+                borderBottom={isLast ? 'none' : '1px solid #242424'}
+                cursor={hasChildren ? 'pointer' : 'default'}
+                onClick={() => hasChildren && onToggle(task.id)}
+                _hover={{ bg: '#1f1f1f' }}
+              >
+                <Box w={`${depth * 16}px`} flexShrink={0} />
+                <Box w="16px" mr={1} display="flex" alignItems="center" justifyContent="center">
+                  {hasChildren ? (
+                    <Box
+                      fontSize="10px"
+                      color="#898989"
+                      lineHeight={1}
+                      userSelect="none"
+                    >
+                      {isColl ? '▶' : '▼'}
+                    </Box>
+                  ) : null}
+                </Box>
+                <Text
+                  fontSize="13px"
+                  color="#fafafa"
+                  lineClamp={1}
+                  userSelect="none"
+                  fontWeight={hasChildren ? 500 : 400}
+                >
+                  {task.title}
+                </Text>
+              </Flex>
+            )
+          })}
+        </Box>
+
+        {/* Body Right (Date Grid) */}
+        <Box flex={1} overflowX="auto">
+          <Box position="relative" minW="800px" h="100%">
+            {/* Background Grid Lines */}
+            <Flex position="absolute" top={0} left={0} right={0} bottom={0} pointerEvents="none">
+              {weeks.map((week, i) => (
+                <Box
+                  key={i}
+                  position="absolute"
+                  left={`${getLeftPercent(week)}%`}
+                  h="100%"
+                  borderLeft="1px solid #242424"
+                />
+              ))}
+              {/* Today Line */}
+              {isTodayInRange && (
+                <Box
+                  position="absolute"
+                  left={`${todayLeft}%`}
+                  top={0}
+                  bottom={0}
+                  w="1px"
+                  bg="rgba(62, 207, 142, 0.4)"
+                  zIndex={1}
+                />
+              )}
+            </Flex>
+
+            {/* Task Bars */}
+            {rows.map(({ task }, i) => {
+              const isLast = i === rows.length - 1
+              
+              const hasStart = task.startDate && isValid(new Date(task.startDate))
+              const hasDue = task.dueDate && isValid(new Date(task.dueDate))
+              
+              const startDate = hasStart ? new Date(task.startDate!) : null
+              const dueDate = hasDue ? new Date(task.dueDate!) : null
+
+              let barContent = null
+
+              if (!startDate || !dueDate) {
+                barContent = (
+                  <Text fontSize="12px" color="#4d4d4d" fontStyle="italic">
+                    — 일정 없음 —
+                  </Text>
+                )
+              } else {
+                const leftP = getLeftPercent(startDate)
+                const widthP = getWidthPercent(startDate, dueDate)
+                
+                barContent = (
+                  <Box
+                    position="absolute"
+                    left={`${leftP}%`}
+                    w={`${widthP}%`}
+                    h="20px"
+                    bg="#2e2e2e"
+                    borderRadius="4px"
+                    overflow="hidden"
+                  >
+                    <Box
+                      h="100%"
+                      w={`${task.progress}%`}
+                      bg="#3ecf8e"
+                      opacity={0.8}
+                    />
+                  </Box>
+                )
+              }
+
+              return (
+                <Flex
+                  key={task.id}
+                  align="center"
+                  h="40px"
+                  px={3}
+                  borderBottom={isLast ? 'none' : '1px solid #242424'}
+                  position="relative"
+                  _hover={{ bg: 'rgba(255, 255, 255, 0.02)' }}
+                >
+                  {barContent}
+                </Flex>
+              )
+            })}
+          </Box>
+        </Box>
+      </Flex>
+    </Box>
+  )
+}

--- a/components/task-list.tsx
+++ b/components/task-list.tsx
@@ -1,13 +1,14 @@
 'use client'
 
 import { useState, useEffect, useCallback } from 'react'
-import { Box, Flex, Text, Button, Heading } from '@chakra-ui/react'
+import { Box, Flex, Text, Button, Heading, Tabs } from '@chakra-ui/react'
 import type { Task } from '@/lib/db/schema'
 import TaskRow from './task-row'
 import TaskFormModal from './task-form-modal'
 import TaskDeleteDialog from './task-delete-dialog'
 import CsvExportButton from './csv-export-button'
 import CsvImportButton from './csv-import-button'
+import GanttView from './gantt-view'
 
 type TreeNode = Task & { children: TreeNode[] }
 
@@ -150,62 +151,115 @@ export default function TaskList() {
           </Flex>
         </Flex>
 
-        {/* 컬럼 헤더 */}
-        {tasks.length > 0 && (
-          <Flex
-            px={4}
-            pb={2}
-            mb={1}
-            gap={3}
-            fontSize="12px"
-            color="#4d4d4d"
-            fontWeight={500}
-            borderBottom="1px solid #242424"
-            style={{ letterSpacing: '0.05em', textTransform: 'uppercase' }}
-          >
-            <Box w="16px" flexShrink={0} />
-            <Box flex={1}>제목</Box>
-            <Box w="80px" flexShrink={0}>진행률</Box>
-            <Box w="72px" flexShrink={0}>상태</Box>
-            <Box w="100px" flexShrink={0} display={{ base: 'none', md: 'block' }}>목표 기한</Box>
-            <Box w="28px" flexShrink={0} />
-          </Flex>
-        )}
+        <Tabs.Root defaultValue="list" variant="enclosed">
+          <Tabs.List bg="#0f0f0f" borderRadius="9999px" p={1} border="1px solid #2e2e2e" display="inline-flex" mb={6}>
+            <Tabs.Trigger
+              value="list"
+              borderRadius="9999px"
+              px={6}
+              py={2}
+              fontSize="14px"
+              fontWeight={500}
+              color="#898989"
+              _selected={{ bg: '#2e2e2e', color: '#fafafa' }}
+              cursor="pointer"
+            >
+              목록 뷰
+            </Tabs.Trigger>
+            <Tabs.Trigger
+              value="gantt"
+              borderRadius="9999px"
+              px={6}
+              py={2}
+              fontSize="14px"
+              fontWeight={500}
+              color="#898989"
+              _selected={{ bg: '#2e2e2e', color: '#fafafa' }}
+              cursor="pointer"
+            >
+              간트 뷰
+            </Tabs.Trigger>
+          </Tabs.List>
 
-        {/* Task 목록 */}
-        {loading ? (
-          <Box textAlign="center" py={16}>
-            <Text color="#898989" fontSize="14px">로딩 중...</Text>
-          </Box>
-        ) : tasks.length === 0 ? (
-          <Box
-            border="1px solid #2e2e2e"
-            borderRadius="8px"
-            py={16}
-            textAlign="center"
-          >
-            <Text color="#898989" fontSize="14px" mb={2}>아직 Task가 없습니다.</Text>
-            <Text color="#4d4d4d" fontSize="13px">상단의 &ldquo;+ Task 추가&rdquo; 버튼으로 첫 Task를 만들어 보세요.</Text>
-          </Box>
-        ) : (
-          <Box border="1px solid #2e2e2e" borderRadius="8px">
-            {rows.map(({ task, depth, hasChildren }, i) => (
-              <TaskRow
-                key={task.id}
-                task={task}
-                depth={depth}
-                hasChildren={hasChildren}
-                isCollapsed={collapsed.has(task.id)}
-                isLast={i === rows.length - 1}
-                onToggle={() => toggleCollapse(task.id)}
-                onEdit={() => setEditingTask(task)}
-                onDelete={() => setDeletingTask(task)}
-                onStatusCycle={() => handleStatusCycle(task)}
-                onAddSubtask={() => openAddSubtask(task.id)}
-              />
-            ))}
-          </Box>
-        )}
+          <Tabs.Content value="list">
+            {/* 컬럼 헤더 */}
+            {tasks.length > 0 && (
+              <Flex
+                px={4}
+                pb={2}
+                mb={1}
+                gap={3}
+                fontSize="12px"
+                color="#4d4d4d"
+                fontWeight={500}
+                borderBottom="1px solid #242424"
+                style={{ letterSpacing: '0.05em', textTransform: 'uppercase' }}
+              >
+                <Box w="16px" flexShrink={0} />
+                <Box flex={1}>제목</Box>
+                <Box w="80px" flexShrink={0}>진행률</Box>
+                <Box w="72px" flexShrink={0}>상태</Box>
+                <Box w="100px" flexShrink={0} display={{ base: 'none', md: 'block' }}>목표 기한</Box>
+                <Box w="28px" flexShrink={0} />
+              </Flex>
+            )}
+
+            {/* Task 목록 */}
+            {loading ? (
+              <Box textAlign="center" py={16}>
+                <Text color="#898989" fontSize="14px">로딩 중...</Text>
+              </Box>
+            ) : tasks.length === 0 ? (
+              <Box
+                border="1px solid #2e2e2e"
+                borderRadius="8px"
+                py={16}
+                textAlign="center"
+              >
+                <Text color="#898989" fontSize="14px" mb={2}>아직 Task가 없습니다.</Text>
+                <Text color="#4d4d4d" fontSize="13px">상단의 &ldquo;+ Task 추가&rdquo; 버튼으로 첫 Task를 만들어 보세요.</Text>
+              </Box>
+            ) : (
+              <Box border="1px solid #2e2e2e" borderRadius="8px">
+                {rows.map(({ task, depth, hasChildren }, i) => (
+                  <TaskRow
+                    key={task.id}
+                    task={task}
+                    depth={depth}
+                    hasChildren={hasChildren}
+                    isCollapsed={collapsed.has(task.id)}
+                    isLast={i === rows.length - 1}
+                    onToggle={() => toggleCollapse(task.id)}
+                    onEdit={() => setEditingTask(task)}
+                    onDelete={() => setDeletingTask(task)}
+                    onStatusCycle={() => handleStatusCycle(task)}
+                    onAddSubtask={() => openAddSubtask(task.id)}
+                  />
+                ))}
+              </Box>
+            )}
+          </Tabs.Content>
+
+          <Tabs.Content value="gantt">
+            {loading ? (
+              <Box textAlign="center" py={16}>
+                <Text color="#898989" fontSize="14px">로딩 중...</Text>
+              </Box>
+            ) : tasks.length === 0 ? (
+              <Box
+                border="1px solid #2e2e2e"
+                borderRadius="8px"
+                py={16}
+                textAlign="center"
+              >
+                <Text color="#898989" fontSize="14px" mb={2}>아직 Task가 없습니다.</Text>
+                <Text color="#4d4d4d" fontSize="13px">상단의 &ldquo;+ Task 추가&rdquo; 버튼으로 첫 Task를 만들어 보세요.</Text>
+              </Box>
+            ) : (
+              <GanttView rows={rows} collapsed={collapsed} onToggle={toggleCollapse} />
+            )}
+          </Tabs.Content>
+        </Tabs.Root>
       </Box>
 
       <TaskFormModal


### PR DESCRIPTION
## Summary

- `components/gantt-view.tsx`를 통한 좌측 트리 + 우측 날짜 그리드 형태의 간트 차트 구현
- Chakra UI Tabs를 사용한 "목록 | 간트" 탭 토글 뷰 추가
- 주(week) 단위 컬럼 헤더 렌더링 및 오늘 날짜 기준 수직선 표시
- `start_date`부터 `due_date`까지의 범위 막대 및 진행률 내부 채우기 구현
- 날짜 정보가 없는 Task에 대해 "— 일정 없음 —" 텍스트 렌더링

## 수동 확인 체크리스트

> 자동화 테스트로 검증되지 않는 항목만 기재한다.

- [ ] 브라우저 창 크기 조절 시 간트 차트 헤더와 그리드 간 가로 스크롤 동기화 확인
- [ ] 뷰 전환(목록 ↔ 간트) 시 레이아웃 깨짐 현상 없는지 확인

closes #7

🤖 Generated with Gemini