### PR TITLE
fix: #30 간트 뷰 Overdue Task 시각 표시 추가

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -25,7 +25,7 @@
 | PR #3 | Phase 6 | CSV Import/Export | ✅ merged ([#22](https://github.com/nami-dihi/claude-vercel-wbs/pull/22)) |
 | PR #4 | Phase 7 | 간트형 시각화 뷰 | ✅ merged ([#26](https://github.com/nami-dihi/claude-vercel-wbs/pull/26)) |
 | PR #5 | Phase 8 | Overdue 시각 표시 (목록 뷰) | ✅ merged ([#29](https://github.com/nami-dihi/claude-vercel-wbs/pull/29)) |
-| PR #5-1 | Phase 8 | Overdue 시각 표시 (간트 뷰 누락 수정) | 🔄 리뷰 대기 ([#30](https://github.com/nami-dihi/claude-vercel-wbs/issues/30)) |
+| PR #5-1 | Phase 8 | Overdue 시각 표시 (간트 뷰 누락 수정) | 🔄 리뷰 대기 ([#31](https://github.com/nami-dihi/claude-vercel-wbs/pull/31)) |
 | PR #6 | Phase 9~10 | CI + 배포 | ⬜ |
 
 > Issue #1은 이미 수동 close됨 (Phase 1 완료). PR #1 merge 시 `closes #2` 로 Issue #2 자동 close 예정.

--- a/PLAN.md
+++ b/PLAN.md
@@ -23,8 +23,9 @@
 | PR #1 | Phase 1~2 | 프로젝트 세팅 + DB 마이그레이션 | ✅ merged ([#13](https://github.com/nami-dihi/claude-vercel-wbs/pull/13)) |
 | PR #2 | Phase 3~5 | Task CRUD + 계층 + 필드 편집 | ✅ merged ([#15](https://github.com/nami-dihi/claude-vercel-wbs/pull/15)) |
 | PR #3 | Phase 6 | CSV Import/Export | ✅ merged ([#22](https://github.com/nami-dihi/claude-vercel-wbs/pull/22)) |
-| PR #4 | Phase 7 | 간트형 시각화 뷰 | 🔄 리뷰 대기 ([#26](https://github.com/nami-dihi/claude-vercel-wbs/pull/26)) |
-| PR #5 | Phase 8 | Overdue 시각 표시 | 🔄 리뷰 대기 ([#29](https://github.com/nami-dihi/claude-vercel-wbs/pull/29)) |
+| PR #4 | Phase 7 | 간트형 시각화 뷰 | ✅ merged ([#26](https://github.com/nami-dihi/claude-vercel-wbs/pull/26)) |
+| PR #5 | Phase 8 | Overdue 시각 표시 (목록 뷰) | ✅ merged ([#29](https://github.com/nami-dihi/claude-vercel-wbs/pull/29)) |
+| PR #5-1 | Phase 8 | Overdue 시각 표시 (간트 뷰 누락 수정) | 🔄 리뷰 대기 ([#30](https://github.com/nami-dihi/claude-vercel-wbs/issues/30)) |
 | PR #6 | Phase 9~10 | CI + 배포 | ⬜ |
 
 > Issue #1은 이미 수동 close됨 (Phase 1 완료). PR #1 merge 시 `closes #2` 로 Issue #2 자동 close 예정.
@@ -120,27 +121,27 @@
 
 ---
 
-## Phase 7 — 간트형 시각화 뷰
+## Phase 7 — 간트형 시각화 뷰 ✅
 
 **커밋 목표:** `feat: #7 간트형 일정 시각화 뷰`
 
-- [ ] `components/gantt-view.tsx` — 좌측 트리 + 우측 날짜 그리드
-- [ ] "목록 | 간트" 탭 토글 (Chakra UI Tabs)
-- [ ] 주(week) 단위 컬럼 헤더 + 오늘 수직선
-- [ ] Task 막대: start_date~due_date, 진행률 채우기
-- [ ] 날짜 없는 Task "— 일정 없음 —" 표시
-- [ ] J13, J14, J16 시나리오 검증
+- [x] `components/gantt-view.tsx` — 좌측 트리 + 우측 날짜 그리드
+- [x] "목록 | 간트" 탭 토글 (Chakra UI Tabs)
+- [x] 주(week) 단위 컬럼 헤더 + 오늘 수직선
+- [x] Task 막대: start_date~due_date, 진행률 채우기
+- [x] 날짜 없는 Task "— 일정 없음 —" 표시
+- [x] J13, J14, J16 시나리오 검증
 
 ---
 
-## Phase 8 — Overdue 시각 표시
+## Phase 8 — Overdue 시각 표시 ✅
 
 **커밋 목표:** `feat: #11 기한 초과(Overdue) Task 시각 표시`
 
 - [x] 목록 뷰: dueDate 빨간 텍스트 + "기한 초과" 배지
-- [ ] 간트 뷰: 막대에 빨간 테두리 또는 빗금 오버레이
+- [x] 간트 뷰: 막대에 빨간 테두리 또는 빗금 오버레이
 - [x] J9 시나리오 검증
-- [ ] J15 시나리오 검증
+- [x] J15 시나리오 검증
 
 ---
 

--- a/components/gantt-view.tsx
+++ b/components/gantt-view.tsx
@@ -11,6 +11,12 @@ interface GanttViewProps {
   onToggle: (id: string) => void
 }
 
+function isOverdue(task: Task) {
+  if (!task.dueDate || task.status === 'done') return false
+  const today = new Date().toLocaleDateString('en-CA', { timeZone: 'Asia/Seoul' }) // 'YYYY-MM-DD'
+  return task.dueDate < today
+}
+
 export default function GanttView({ rows, collapsed, onToggle }: GanttViewProps) {
   // Helper date functions
   const addDays = (date: Date, days: number) => {
@@ -203,12 +209,13 @@ export default function GanttView({ rows, collapsed, onToggle }: GanttViewProps)
             {/* Task Bars */}
             {rows.map(({ task }, i) => {
               const isLast = i === rows.length - 1
-              
+
               const hasStart = task.startDate && isValid(new Date(task.startDate))
               const hasDue = task.dueDate && isValid(new Date(task.dueDate))
-              
+
               const startDate = hasStart ? new Date(task.startDate!) : null
               const dueDate = hasDue ? new Date(task.dueDate!) : null
+              const overdue = isOverdue(task)
 
               let barContent = null
 
@@ -221,7 +228,7 @@ export default function GanttView({ rows, collapsed, onToggle }: GanttViewProps)
               } else {
                 const leftP = getLeftPercent(startDate)
                 const widthP = getWidthPercent(startDate, dueDate)
-                
+
                 barContent = (
                   <Box
                     position="absolute"
@@ -231,13 +238,24 @@ export default function GanttView({ rows, collapsed, onToggle }: GanttViewProps)
                     bg="#2e2e2e"
                     borderRadius="4px"
                     overflow="hidden"
+                    border={overdue ? '2px solid #f87171' : 'none'}
                   >
                     <Box
                       h="100%"
                       w={`${task.progress}%`}
-                      bg="#3ecf8e"
+                      bg={overdue ? '#f87171' : '#3ecf8e'}
                       opacity={0.8}
                     />
+                    {overdue && (
+                      <Box
+                        position="absolute"
+                        inset={0}
+                        pointerEvents="none"
+                        style={{
+                          background: 'repeating-linear-gradient(45deg, transparent, transparent 4px, rgba(248,113,113,0.15) 4px, rgba(248,113,113,0.15) 8px)',
+                        }}
+                      />
+                    )}
                   </Box>
                 )
               }


### PR DESCRIPTION
## Summary

- `isOverdue()` 함수 추가 — `dueDate < 오늘(Asia/Seoul)` 이고 `status !== 'done'` 조건 판정
- Overdue 막대에 빨강 테두리(`2px solid #f87171`) 적용
- 진행률 채움 색도 빨강(`#f87171`)으로 변경하여 경고 강조
- 45° 빗금 오버레이(`repeating-linear-gradient`) 추가로 일반 막대와 명확히 구분
- 상태를 "완료"로 전환 시 모든 경고 표시 즉시 해제

closes #30

## 테스트

- J15 통과 ✅ — Overdue 막대에 빨강 테두리 + 빗금 표시
- J15 완료 전환 ✅ — 상태 "완료" 시 경고 즉시 사라짐

🤖 Generated with [Claude Code](https://claude.com/claude-code)