### PR TITLE
fix: #32 Overdue 날짜 판별 타임존 Asia/Seoul 통일

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -26,7 +26,7 @@
 | PR #4 | Phase 7 | 간트형 시각화 뷰 | ✅ merged ([#26](https://github.com/nami-dihi/claude-vercel-wbs/pull/26)) |
 | PR #5 | Phase 8 | Overdue 시각 표시 (목록 뷰) | ✅ merged ([#29](https://github.com/nami-dihi/claude-vercel-wbs/pull/29)) |
 | PR #5-1 | Phase 8 | Overdue 시각 표시 (간트 뷰 누락 수정) | ✅ merged ([#31](https://github.com/nami-dihi/claude-vercel-wbs/pull/31)) |
-| PR #5-2 | P0 버그픽스 | Overdue 타임존 불일치 수정 (#32) | 🔄 리뷰 대기 |
+| PR #5-2 | P0 버그픽스 | Overdue 타임존 불일치 수정 (#32) | 🔄 리뷰 대기 ([#34](https://github.com/nami-dihi/claude-vercel-wbs/pull/34)) |
 | PR #6 | Phase 9~10 | CI + 배포 | ⬜ |
 
 > Issue #1은 이미 수동 close됨 (Phase 1 완료). PR #1 merge 시 `closes #2` 로 Issue #2 자동 close 예정.

--- a/PLAN.md
+++ b/PLAN.md
@@ -25,7 +25,8 @@
 | PR #3 | Phase 6 | CSV Import/Export | ✅ merged ([#22](https://github.com/nami-dihi/claude-vercel-wbs/pull/22)) |
 | PR #4 | Phase 7 | 간트형 시각화 뷰 | ✅ merged ([#26](https://github.com/nami-dihi/claude-vercel-wbs/pull/26)) |
 | PR #5 | Phase 8 | Overdue 시각 표시 (목록 뷰) | ✅ merged ([#29](https://github.com/nami-dihi/claude-vercel-wbs/pull/29)) |
-| PR #5-1 | Phase 8 | Overdue 시각 표시 (간트 뷰 누락 수정) | 🔄 리뷰 대기 ([#31](https://github.com/nami-dihi/claude-vercel-wbs/pull/31)) |
+| PR #5-1 | Phase 8 | Overdue 시각 표시 (간트 뷰 누락 수정) | ✅ merged ([#31](https://github.com/nami-dihi/claude-vercel-wbs/pull/31)) |
+| PR #5-2 | P0 버그픽스 | Overdue 타임존 불일치 수정 (#32) | 🔄 리뷰 대기 |
 | PR #6 | Phase 9~10 | CI + 배포 | ⬜ |
 
 > Issue #1은 이미 수동 close됨 (Phase 1 완료). PR #1 merge 시 `closes #2` 로 Issue #2 자동 close 예정.

--- a/components/task-row.tsx
+++ b/components/task-row.tsx
@@ -21,7 +21,7 @@ interface Props {
 
 function isOverdue(task: Task) {
   if (!task.dueDate || task.status === 'done') return false
-  const today = new Date().toLocaleDateString('en-CA') // 'YYYY-MM-DD'
+  const today = new Date().toLocaleDateString('en-CA', { timeZone: 'Asia/Seoul' }) // 'YYYY-MM-DD'
   return task.dueDate < today
 }
 


### PR DESCRIPTION
## Summary

- `components/task-row.tsx`의 `isOverdue` 함수에서 `toLocaleDateString` 호출 시 `{ timeZone: 'Asia/Seoul' }` 옵션 추가
- 기존에 `gantt-view.tsx`는 이미 `Asia/Seoul` 기준이었으나, `task-row.tsx`는 시스템 타임존(Vercel 배포 환경에서는 UTC)을 사용하고 있어 두 뷰 간 Overdue 판별 기준이 불일치하는 버그가 있었음
- 이제 목록 뷰·간트 뷰 모두 한국 시간 기준으로 동일하게 Overdue를 판별함

closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)